### PR TITLE
cpus: share clock between QEMU/libcpu

### DIFF
--- a/kvm-all.c
+++ b/kvm-all.c
@@ -110,6 +110,10 @@ struct KVMState
 #ifdef KVM_CAP_DEV_SNAPSHOT
     int dev_snapshot;
 #endif
+
+#ifdef KVM_CAP_CPU_CLOCK_SCALE
+    int cpu_clock_scale;
+#endif
 };
 
 KVMState *kvm_state;
@@ -1215,6 +1219,22 @@ static int kvm_dev_restore_snapshot(void)
 
 #endif
 
+#ifdef KVM_CAP_CPU_CLOCK_SCALE
+int kvm_has_cpu_clock_scale(void)
+{
+    if (!kvm_enabled()) {
+        return 0;
+    }
+
+    return kvm_state->cpu_clock_scale;
+}
+#else
+int kvm_has_cpu_clock_scale(void)
+{
+    return 0;
+}
+#endif
+
 extern volatile bool g_main_loop_thread_inited;
 static void kvm_clone_process(CPUArchState *env)
 {
@@ -1351,6 +1371,10 @@ int kvm_init(void)
 
 #ifdef KVM_CAP_DEV_SNAPSHOT
     s->dev_snapshot = kvm_check_extension(s, KVM_CAP_DEV_SNAPSHOT);
+#endif
+
+#ifdef KVM_CAP_CPU_CLOCK_SCALE
+    s->cpu_clock_scale = kvm_check_extension(s, KVM_CAP_CPU_CLOCK_SCALE);
 #endif
 
     ret = kvm_arch_init(s);

--- a/kvm.h
+++ b/kvm.h
@@ -66,6 +66,7 @@ int kvm_has_mem_rw(void);
 
 int kvm_disk_rw(void *buffer, uint64_t sector, int count, int is_write);
 int kvm_has_disk_rw(void);
+int kvm_has_cpu_clock_scale(void);
 
 #ifdef NEED_CPU_H
 int kvm_init_vcpu(CPUArchState *env);

--- a/linux-headers/linux/kvm.h
+++ b/linux-headers/linux/kvm.h
@@ -333,6 +333,9 @@ struct kvm_run {
         struct kvm_sync_regs regs;
         char padding[1024];
     } s;
+
+    /* Share timer's clock scaling over KVM */
+    int32_t cpu_clock_scale_factor;
 };
 
 /* for KVM_REGISTER_COALESCED_MMIO / KVM_UNREGISTER_COALESCED_MMIO */
@@ -769,8 +772,11 @@ struct kvm_ppc_smmu_info {
 #define KVM_CAP_PPC_ENABLE_HCALL 104
 #define KVM_CAP_CHECK_EXTENSION_VM 105
 
-/***** custom capability for symbolic execution support *****/
+/***** custom capabilities for symbolic execution support *****/
 #define KVM_CAP_MEM_RW 1021
+
+/* This capability allows a clock to be slowed down via a clock scaling factor */
+#define KVM_CAP_CPU_CLOCK_SCALE 1022
 
 /* This capability forces CPU exit */
 #define KVM_CAP_FORCE_EXIT 255


### PR DESCRIPTION
Previously QEMU and libcpu maintained their own timer state. However, when performing symbolic execution the scaling factor would only be applied to the libcpu clock, and **not** the QEMU clock. This meant that the QEMU clock continued to run at normal speed and hence would constantly interrupt symbolic execution (in KLEE), causing S2E to "get stuck".

To fix this problem we share a single timer state between QEMU and libcpu via the KVM interface. So when we apply scaling in libcpu, the QEMU clock will also be scaled. Because of the shared clock all accesses to the timer state are controlled by a lock.