### PR TITLE
trace: remove malloc tracing

### DIFF
--- a/trace-events
+++ b/trace-events
@@ -25,11 +25,6 @@
 #
 # The <format-string> should be a sprintf()-compatible format string.
 
-# qemu-malloc.c
-g_malloc(size_t size, void *ptr) "size %zu ptr %p"
-g_realloc(void *ptr, size_t size, void *newptr) "ptr %p size %zu newptr %p"
-g_free(void *ptr) "ptr %p"
-
 # osdep.c
 qemu_memalign(size_t alignment, size_t size, void *ptr) "alignment %zu size %zu ptr %p"
 qemu_vmalloc(size_t size, void *ptr) "size %zu ptr %p"

--- a/vl.c
+++ b/vl.c
@@ -2316,26 +2316,6 @@ static const QEMUOption *lookup_opt(int argc, char **argv,
     return popt;
 }
 
-static gpointer malloc_and_trace(gsize n_bytes)
-{
-    void *ptr = malloc(n_bytes);
-    trace_g_malloc(n_bytes, ptr);
-    return ptr;
-}
-
-static gpointer realloc_and_trace(gpointer mem, gsize n_bytes)
-{
-    void *ptr = realloc(mem, n_bytes);
-    trace_g_realloc(mem, n_bytes, ptr);
-    return ptr;
-}
-
-static void free_and_trace(gpointer mem)
-{
-    trace_g_free(mem);
-    free(mem);
-}
-
 int qemu_init_main_loop(void)
 {
     return main_loop_init();
@@ -2422,18 +2402,12 @@ int main(int argc, char **argv, char **envp)
     int defconfig = 1;
     const char *log_mask = NULL;
     const char *log_file = NULL;
-    GMemVTable mem_trace = {
-        .malloc = malloc_and_trace,
-        .realloc = realloc_and_trace,
-        .free = free_and_trace,
-    };
     const char *trace_events = NULL;
     const char *trace_file = NULL;
 
     atexit(qemu_run_exit_notifiers);
     error_set_progname(argv[0]);
 
-    g_mem_set_vtable(&mem_trace);
     if (!g_thread_supported()) {
 #if !GLIB_CHECK_VERSION(2, 31, 0)
         g_thread_init(NULL);


### PR DESCRIPTION
I got sick of seeing that Glib warning about "custom memory allocation vtable not supported", so I took the upstream patch to fix it. It should also reduce confusion for new-comers, i.e. https://github.com/S2E/s2e-env/issues/39 :)

https://git.qemu.org/?p=qemu.git;a=commitdiff;h=98cf48f60aa4999f5b2808569a193a401a390e6a

> The malloc vtable is not supported anymore in glib, because it broke when constructors called g_malloc. Remove tracing of g_malloc, g_realloc and g_free calls.
> 
> Note that, for systemtap users, glib also provides tracepoints glib.mem_alloc, glib.mem_free, glib.mem_realloc, glib.slice_alloc and glib.slice_free.