### PR TITLE
cpus: fix iothread deadlock on s2e forking

### DIFF
--- a/include/sysemu/cpus.h
+++ b/include/sysemu/cpus.h
@@ -42,4 +42,6 @@ void list_cpus(FILE *f, fprintf_function cpu_fprintf, const char *optarg);
 
 void qemu_tcg_configure(QemuOpts *opts, Error **errp);
 
+void register_atfork_cb(void);
+
 #endif

--- a/vl.c
+++ b/vl.c
@@ -4795,6 +4795,10 @@ int main(int argc, char **argv, char **envp)
     accel_setup_post(current_machine);
     os_setup_post();
 
+#ifdef CONFIG_POSIX
+    register_atfork_cb();
+#endif
+
     main_loop();
 
     if (periodic_screenshot) {


### PR DESCRIPTION
When s2e forks, it only forks the current vcpu thread. But the qemu_global_mutex iothread lock could be already locked by another thread, thus causing deadlock. We have to accquire the lock right before forking.