### PR TITLE
kvm: fix clock scaling monotonicity assertion

### DIFF
--- a/cpus.c
+++ b/cpus.c
@@ -349,7 +349,7 @@ static int64_t cpu_get_clock_locked(void)
         /* Compute how much real time elapsed since last request */
         int64_t cur_clock = get_clock() + timers_state.cpu_clock_offset;
         int64_t increment = cur_clock - timers_state.cpu_clock_prev;
-        assert(increment > 0);
+        assert(increment >= 0);
 
         /* Slow the clock down according to the scale */
         int64_t result = timers_state.cpu_clock_prev_scaled + increment / timers_state.cpu_clock_scale_factor;


### PR DESCRIPTION
In HyperV, successive calls can happen with zero time increase on the monotonic clock.

Closes S2E/s2e-env#170 - see issue for more information.