### PR TITLE
Build fixes for Ubuntu 22.04

### DIFF
--- a/include/ui/egl-helpers.h
+++ b/include/ui/egl-helpers.h
@@ -43,7 +43,7 @@ void egl_dmabuf_release_texture(QemuDmaBuf *dmabuf);
 
 #endif
 
-EGLSurface qemu_egl_init_surface_x11(EGLContext ectx, Window win);
+EGLSurface qemu_egl_init_surface_x11(EGLContext ectx, EGLNativeWindowType win);
 
 int qemu_egl_init_dpy_x11(EGLNativeDisplayType dpy, DisplayGLMode mode);
 int qemu_egl_init_dpy_mesa(EGLNativeDisplayType dpy, DisplayGLMode mode);

--- a/scsi/qemu-pr-helper.c
+++ b/scsi/qemu-pr-helper.c
@@ -547,7 +547,8 @@ static int multipath_pr_out(int fd, const uint8_t *cdb, uint8_t *sense,
                 scsi_build_sense(sense, SENSE_CODE(INVALID_PARAM));
                 return CHECK_CONDITION;
             }
-
+            #pragma GCC diagnostic push
+            #pragma GCC diagnostic ignored "-Warray-bounds"
             paramp.trnptid_list[paramp.num_transportid++] = id;
         }
     }

--- a/ui/egl-helpers.c
+++ b/ui/egl-helpers.c
@@ -320,7 +320,7 @@ void egl_dmabuf_release_texture(QemuDmaBuf *dmabuf)
 
 /* ---------------------------------------------------------------------- */
 
-EGLSurface qemu_egl_init_surface_x11(EGLContext ectx, Window win)
+EGLSurface qemu_egl_init_surface_x11(EGLContext ectx, EGLNativeWindowType win)
 {
     EGLSurface esurface;
     EGLBoolean b;


### PR DESCRIPTION
- Changed the component to use EGLNativeWindowType instead of Window type which is not defined anymore with the most updated libraries on 22.04. (approach as of https://lists.gnu.org/archive/html/qemu-devel/2019-01/msg03616.html).

- Silenced warning on out-of-bound.